### PR TITLE
throw error instead of returning false

### DIFF
--- a/bioio_dv/reader.py
+++ b/bioio_dv/reader.py
@@ -50,7 +50,11 @@ class Reader(reader.Reader):
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
-        return DVFile.is_supported_file(path)
+        if not DVFile.is_supported_file(path):
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-dv", path, "DV file format not supported."
+            )
+        return True
 
     def __init__(self, image: types.PathLike, fs_kwargs: Dict[str, Any] = {}):
         self._fs, self._path = io.pathlike_to_fs(
@@ -65,10 +69,7 @@ class Reader(reader.Reader):
                 f"Received URI: {self._path}, which points to {type(self._fs)}."
             )
 
-        if not self._is_supported_image(self._fs, self._path):
-            raise exceptions.UnsupportedFileFormatError(
-                self.__class__.__name__, self._path
-            )
+        self._is_supported_image(self._fs, self._path)
 
     @property
     def scenes(self) -> Tuple[str, ...]:


### PR DESCRIPTION
### Link to Relevant Issue
https://github.com/bioio-devs/bioio-bioformats/issues/21
This pull request resolves #

### Description of Changes
when checking if a file is supported, throw an error instead of returning false, so we can get some message reporting back to the user